### PR TITLE
Fix README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ async fn main() -> anyhow::Result<()> {
     println!("Done!");
 
     Ok(())
+}
 ```
 
 ## Contributing


### PR DESCRIPTION
Added end of curly brace in the example so it works when pasted to a file, and ran with `cargo run`.