### PR TITLE
Comment uncommented `dbg`s

### DIFF
--- a/lego-powered-up/src/notifications.rs
+++ b/lego-powered-up/src/notifications.rs
@@ -1454,9 +1454,9 @@ impl PortOutputCommandFormat {
                     ((*use_acc_profile as u8) << 1) | (*use_dec_profile as u8);
                 let speed = speed.to_le_bytes()[0];
                 let max_power = max_power.to_le_bytes()[0];
-                dbg!(time);
+                //dbg!(time);
                 let time = time.to_le_bytes();
-                dbg!(time);
+                //dbg!(time);
                 let mut bytes = vec![
                     // Header
                     0, // len

--- a/lego-powered-up/src/setup.rs
+++ b/lego-powered-up/src/setup.rs
@@ -11,7 +11,7 @@ pub async fn single_hub() -> Result<ConnectedHub> {
     println!("Waiting for hub...");
     let hub = pu.wait_for_hub().await?;
     println!("Connecting to hub...");
-    dbg!(&hub);
+    //dbg!(&hub);
 
     Ok(ConnectedHub::setup_hub(
         pu.create_hub(&hub).await.expect("Error creating hub"),


### PR DESCRIPTION
There are three uncommented `dbg`s that make my app write unwanted output (one in `setup.rs`, two in `notifications.rs`). I commented them because I want to use it in a CLI app and I don't want the ugly debug output from libraries.